### PR TITLE
feat: add task store

### DIFF
--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -1,0 +1,58 @@
+import { create } from "zustand";
+import { Task, QuadrantType } from "@/types/pomodoro";
+
+interface TasksState {
+  tasks: Task[];
+  isLoading: boolean;
+  setTasks: (tasks: Task[]) => void;
+  addTask: (task: Task) => void;
+  updateTask: (id: string, updates: Partial<Task>) => void;
+  deleteTask: (id: string) => void;
+  toggleTaskCompleted: (id: string) => void;
+  getTaskById: (id: string) => Task | undefined;
+  getTasksByQuadrant: (quadrant: QuadrantType) => Task[];
+  setIsLoading: (isLoading: boolean) => void;
+  clearTasks: () => void;
+}
+
+export const useTasksStore = create<TasksState>((set, get) => ({
+  tasks: [],
+  isLoading: false,
+
+  setTasks: (tasks) => set({ tasks }),
+
+  addTask: (task) =>
+    set((state) => ({
+      tasks: [...state.tasks, task],
+    })),
+
+  updateTask: (id, updates) =>
+    set((state) => ({
+      tasks: state.tasks.map((task) =>
+        task.id === id ? { ...task, ...updates, updatedAt: new Date() } : task
+      ),
+    })),
+
+  deleteTask: (id) =>
+    set((state) => ({
+      tasks: state.tasks.filter((task) => task.id !== id),
+    })),
+
+  toggleTaskCompleted: (id) =>
+    set((state) => ({
+      tasks: state.tasks.map((task) =>
+        task.id === id
+          ? { ...task, completed: !task.completed, updatedAt: new Date() }
+          : task
+      ),
+    })),
+
+  getTaskById: (id) => get().tasks.find((task) => task.id === id),
+
+  getTasksByQuadrant: (quadrant) =>
+    get().tasks.filter((task) => task.quadrant === quadrant),
+
+  setIsLoading: (isLoading) => set({ isLoading }),
+
+  clearTasks: () => set({ tasks: [] }),
+}));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce a Zustand tasks store providing CRUD, completion toggle, selectors, loading flag, and `updatedAt` updates.
> 
> - **State management (`src/store/tasks.ts`)**:
>   - Add `useTasksStore` (Zustand) managing `Task[]` and `isLoading`.
>   - CRUD actions: `setTasks`, `addTask`, `updateTask` (sets `updatedAt`), `deleteTask`, `toggleTaskCompleted` (updates `updatedAt`).
>   - Selectors: `getTaskById`, `getTasksByQuadrant`.
>   - Utilities: `setIsLoading`, `clearTasks`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8c850a1097f865009c849f1f946095519b510cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->